### PR TITLE
chore: bump claws version number + enable the new rule

### DIFF
--- a/.github/workflows/claws.yml
+++ b/.github/workflows/claws.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set Up Ruby
         uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2.3'
       - name: Get Claws Config
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/claws.yml
+++ b/.github/workflows/claws.yml
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
       - name: Set Up Claws
         run: |
-          gem install claws-scan -v 0.7.3
+          gem install claws-scan -v 0.9.0
       - name: Analyze New/Changed Workflows
         env:
           CHANGED_FILES: ${{ needs.changed_workflows.outputs.files }}

--- a/.github/workflows/claws.yml
+++ b/.github/workflows/claws.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           repository: betterment/security-configs
           path: security-configs/
+          ref: main
       # We have to do this `mv` ourselves because for some reason, actions/checkout
       # doesn't support absolute paths OR relative paths that point outside of the
       # working directory. Absolutely bonkers.

--- a/claws/config.yml
+++ b/claws/config.yml
@@ -15,3 +15,4 @@ Enabled:
   BulkPermissions:
   Shellcheck:
     shellcheck_bin: "/usr/bin/shellcheck"
+  CheckoutWithStaticCredentials:


### PR DESCRIPTION
Claws has had a couple of changes since the last version. This updates the version we're using for the org and also updates the claws configuration file to enable the new rule that was added in https://github.com/Betterment/claws/pull/7. Need to wait on https://github.com/Betterment/claws/pull/8 being merged first though!