### PR TITLE
chore: Add 'anthropics' to trusted authors list

### DIFF
--- a/claws/config.yml
+++ b/claws/config.yml
@@ -9,7 +9,7 @@ Enabled:
   CommandInjection:
   AutomaticMerge:
   UnpinnedAction:
-    trusted_authors: ["Betterment", "actions"]
+    trusted_authors: ["Betterment", "actions", "anthropics"]
   UnsafeCheckout:
   InheritedSecrets:
   BulkPermissions:


### PR DESCRIPTION
We'd love to add anthropics to the list of trusted GitHub orgs at least while we trial claude-code in GitHub CI to avoid having to pin new versions as they are released (which currently happens almost daily).