### PR TITLE
chore: allow more runners

### DIFF
--- a/claws/config.yml
+++ b/claws/config.yml
@@ -5,7 +5,7 @@ Enabled:
   EmptyName:
   RiskyTriggers:
   UnapprovedRunners:
-    allowed_runners: ["ubuntu-latest", "macos-12", "macos-15", "macos-latest", "mobile_linux_8_core", "self-hosted"]
+    allowed_runners: ["ubuntu-latest", "macos-12", "macos-15", "macos-latest", "mobile_linux_8_core", "mobile_linux_16_core", "macos-26", "self-hosted"]
   CommandInjection:
   AutomaticMerge:
   UnpinnedAction:


### PR DESCRIPTION
1. Allows a beefier mobile runner that helped with build flakes
2. Allows `macos-26` which supports Xcode and iOS 26 for iOS builds that use `Icon Composer` icon files