### PR TITLE
chore: delete .policy.yml

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,3 +1,0 @@
-remote: Betterment/policy-bot-config
-path: security-policy.yml
-ref: main


### PR DESCRIPTION
we don't need this custom file anymore because it's duplicative of the default policy.yml file now that we're doing certified reviewers.