### PR TITLE
chore: Allow ubuntu-slim and ubuntu-24.04-arm runners

### DIFF
--- a/claws/config.yml
+++ b/claws/config.yml
@@ -7,6 +7,8 @@ Enabled:
   UnapprovedRunners:
     allowed_runners:
       - ubuntu-latest
+      - ubuntu-slim
+      - ubuntu-24.04-arm
       - macos-12
       - macos-15
       - macos-latest

--- a/claws/config.yml
+++ b/claws/config.yml
@@ -5,7 +5,15 @@ Enabled:
   EmptyName:
   RiskyTriggers:
   UnapprovedRunners:
-    allowed_runners: ["ubuntu-latest", "macos-12", "macos-15", "macos-latest", "mobile_linux_8_core", "mobile_linux_16_core", "macos-26", "self-hosted"]
+    allowed_runners:
+      - ubuntu-latest
+      - macos-12
+      - macos-15
+      - macos-latest
+      - mobile_linux_8_core
+      - mobile_linux_16_core
+      - macos-26
+      - self-hosted
   CommandInjection:
   AutomaticMerge:
   UnpinnedAction:


### PR DESCRIPTION
See here for the official image list: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

The `ubuntu-slim` image is 1/3 the price of ubuntu-latest ([reference](https://docs.github.com/en/billing/reference/actions-runner-pricing)). Many GitHub actions require very little compute, so this is a good choice in those cases.

I've also added `ubuntu-24.04-arm`. These images are marginally cheaper, but are reported to perform better in some cases ([reference](https://github.com/orgs/community/discussions/148648)).